### PR TITLE
Correct the team adding usage

### DIFF
--- a/.github/invite-contributors.yml
+++ b/.github/invite-contributors.yml
@@ -1,2 +1,2 @@
 # Team Name
-contributors
+team: contributors


### PR DESCRIPTION
## Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [Conventional Commit](http://conventionalcommits.org/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Wrong usage of adding a team name


## What is the new behavior?
The correct usage of adding a team name

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->



## Other information

Hi, @ajsb85 / @Gianfranco97 

This PR adds the change to the invite contributors file in order to correct the usage of adding team names