### PR TITLE
Change link in Readme & add flag to invite-contributors file

### DIFF
--- a/.github/invite-contributors.yml
+++ b/.github/invite-contributors.yml
@@ -1,2 +1,3 @@
+isOutside: true
 # Team Name
 team: contributors

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See [the tags section of our GitHub project](https://github.com/glpi-project/nod
 ## Contact
 
 For notices about major changes and general discussion of GLPI development, subscribe to the [/r/glpi](http://www.reddit.com/r/glpi) subreddit.
-You can also chat with us via IRC in [#GLPI on freenode](http://webchat.freenode.net/?channels=GLPI]) or [@glpien on Telegram](https://t.me/glpien).
+You can also chat with us via IRC in [#GLPI on freenode](http://webchat.freenode.net/?channels=GLPI) or [@glpien on Telegram](https://t.me/glpien).
 
 ## Contribute
 


### PR DESCRIPTION
## Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [Conventional Commit](http://conventionalcommits.org/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The IRC link adds an square bracket at the end of # GLPI
There's missing a flag to add contributors as outside collaborators
Issue #2 


## What is the new behavior?
Link fixed and flag added

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->



## Other information
Hi, @ajsb85 

This PR closes #2 

Related PR:

* #25 
* #8 
* #10 